### PR TITLE
Change PIL to Pillow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         'lxml',
         'docopt',
-        'PIL',
+        'Pillow',
     ],
     package_data={'justext': ['stoplists/*.txt']},
     test_suite='tests',


### PR DESCRIPTION
The PIL package has ceased to exist.
See: http://stackoverflow.com/questions/20060096/installing-pil-with-pip#20061019
